### PR TITLE
Minify release builds and strip logging

### DIFF
--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -65,7 +65,7 @@ react {
 /**
  * Set this to true to Run Proguard on Release builds to minify the Java bytecode.
  */
-def enableProguardInReleaseBuilds = false
+def enableProguardInReleaseBuilds = true
 
 /**
  * The preferred build flavor of JavaScriptCore (JSC)

--- a/template/android/app/proguard-rules.pro
+++ b/template/android/app/proguard-rules.pro
@@ -9,6 +9,16 @@
 
 # Add any project specific keep options here:
 
-# com.mypackage should match the package value in your app/src/main/AndroidManifest.xml file.
--keep class com.mypackage.BuildConfig { *; }
+# com.projectname should match the package value in your app/src/main/AndroidManifest.xml file.
+-keep class com.projectname.BuildConfig { *; }
 -keepresources string/build_config_package
+
+# Strip logging from production builds
+-assumenosideeffects class android.util.Log {
+    public static boolean isLoggable(java.lang.String, int);
+    public static int v(...);
+    public static int i(...);
+    public static int w(...);
+    public static int d(...);
+    public static int e(...);
+}

--- a/template/ios/Podfile.lock
+++ b/template/ios/Podfile.lock
@@ -509,7 +509,7 @@ PODS:
     - React-Core
   - RNDeviceInfo (10.9.0):
     - React-Core
-  - RNGestureHandler (2.12.1):
+  - RNGestureHandler (2.13.1):
     - React-Core
   - RNReactNativeHapticFeedback (2.2.0):
     - React-Core
@@ -823,7 +823,7 @@ SPEC CHECKSUMS:
   ReactCommon: 4b2bdcb50a3543e1c2b2849ad44533686610826d
   RNCAsyncStorage: c913ede1fa163a71cea118ed4670bbaaa4b511bb
   RNDeviceInfo: 02ea8b23e2280fa18e00a06d7e62804d74028579
-  RNGestureHandler: c0d04458598fcb26052494ae23dda8f8f5162b13
+  RNGestureHandler: 38aa38413896620338948fbb5c90579a7b1c3fde
   RNReactNativeHapticFeedback: ec56a5f81c3941206fd85625fa669ffc7b4545f9
   RNReanimated: 99aa8c96151abbc2d7e737a56ec62aca709f0c92
   RNScreens: 85d3880b52d34db7b8eeebe2f1a0e807c05e69fa


### PR DESCRIPTION
# 📚 Description

As a security measure, we make it harder to reverse engineer code by enabling minification and by stripping logs from the build output on release builds

# 📖  Note

The Podfile.lock wasn't up-to-date so I also updated it