### PR TITLE
Refresh queries when the app gains focus and when changing the language

### DIFF
--- a/template/src/hooks/use-invalidate-queries-on-language-change.ts
+++ b/template/src/hooks/use-invalidate-queries-on-language-change.ts
@@ -1,0 +1,21 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export function useInvalidateQueriesOnLanguageChange() {
+  const { i18n } = useTranslation();
+  const languageRef = useRef(i18n.language);
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (i18n.language === languageRef.current) {
+      return;
+    }
+
+    // Evict everything from the cache but don't refetch anything. Queries will
+    // be refetched when they become "enabled" when their screen gains focus.
+    queryClient.invalidateQueries({
+      refetchType: 'none',
+    });
+  }, [queryClient, i18n.language]);
+}

--- a/template/src/hooks/use-set-query-focus-manager.ts
+++ b/template/src/hooks/use-set-query-focus-manager.ts
@@ -1,0 +1,13 @@
+import { focusManager } from '@tanstack/react-query';
+import { useEffect } from 'react';
+import { AppState } from 'react-native';
+
+export function useSetQueryFocusManager() {
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', (appState) => {
+      focusManager.setFocused(appState === 'active');
+    });
+
+    return () => subscription.remove();
+  }, []);
+}

--- a/template/src/hooks/use-set-query-online-manager.ts
+++ b/template/src/hooks/use-set-query-online-manager.ts
@@ -1,0 +1,11 @@
+import { useEffect } from 'react';
+import NetInfo from '@react-native-community/netinfo';
+import { onlineManager } from '@tanstack/react-query';
+
+export function useSetQueryOnlineManager() {
+  useEffect(() => {
+    return NetInfo.addEventListener((state) => {
+      onlineManager.setOnline(!!state.isConnected);
+    });
+  }, []);
+}

--- a/template/src/navigation/RootNavigator.tsx
+++ b/template/src/navigation/RootNavigator.tsx
@@ -4,9 +4,7 @@ import {
   NativeStackNavigationProp,
   NativeStackScreenProps,
 } from '@react-navigation/native-stack';
-import React, { useEffect, useRef } from 'react';
-import { useTranslation } from 'react-i18next';
-import { useQueryClient } from '@tanstack/react-query';
+import React from 'react';
 import { HomeScreen } from '../screens/Home';
 import { ExampleBottomSheet } from '~/screens/bottom-sheets/ExampleBottomSheet';
 import { SecretConfigScreen } from '~/screens/SecretConfig';
@@ -26,25 +24,9 @@ export type RootStackScreenProps<Screen extends keyof RootStackParamList> =
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
 function RootNavigator() {
-  const { i18n } = useTranslation();
-  const languageRef = useRef(i18n.language);
-  const queryClient = useQueryClient();
-
   const secretPanelEnabled = useApplicationConfiguration(
     'SECRET_PANEL_ENABLED'
   );
-
-  useEffect(() => {
-    if (i18n.language === languageRef.current) {
-      return;
-    }
-
-    // Evict everything from the cache but don't refetch anything. Queries will
-    // be refetched when they become "enabled" when their screen gains focus.
-    queryClient.invalidateQueries({
-      refetchType: 'none',
-    });
-  }, [queryClient, i18n.language]);
 
   return (
     <Stack.Navigator screenOptions={{ headerShown: false }}>

--- a/template/src/navigation/RootNavigator.tsx
+++ b/template/src/navigation/RootNavigator.tsx
@@ -4,7 +4,9 @@ import {
   NativeStackNavigationProp,
   NativeStackScreenProps,
 } from '@react-navigation/native-stack';
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useQueryClient } from '@tanstack/react-query';
 import { HomeScreen } from '../screens/Home';
 import { ExampleBottomSheet } from '~/screens/bottom-sheets/ExampleBottomSheet';
 import { SecretConfigScreen } from '~/screens/SecretConfig';
@@ -24,9 +26,25 @@ export type RootStackScreenProps<Screen extends keyof RootStackParamList> =
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
 function RootNavigator() {
+  const { i18n } = useTranslation();
+  const languageRef = useRef(i18n.language);
+  const queryClient = useQueryClient();
+
   const secretPanelEnabled = useApplicationConfiguration(
     'SECRET_PANEL_ENABLED'
   );
+
+  useEffect(() => {
+    if (i18n.language === languageRef.current) {
+      return;
+    }
+
+    // Evict everything from the cache but don't refetch anything. Queries will
+    // be refetched when they become "enabled" when their screen gains focus.
+    queryClient.invalidateQueries({
+      refetchType: 'none',
+    });
+  }, [queryClient, i18n.language]);
 
   return (
     <Stack.Navigator screenOptions={{ headerShown: false }}>

--- a/template/src/navigation/index.tsx
+++ b/template/src/navigation/index.tsx
@@ -1,25 +1,37 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
   NavigationContainer,
   DefaultTheme,
   DarkTheme,
 } from '@react-navigation/native';
 import { AppState } from 'react-native';
-import { focusManager } from '@tanstack/react-query';
+import { focusManager, onlineManager } from '@tanstack/react-query';
+import NetInfo from '@react-native-community/netinfo';
 import RootNavigator from './RootNavigator';
 import { withBoundary } from '~/components/boundary';
 import { useColorSchemeValue } from '~/hooks/use-color-scheme-value';
 import { useKillswitch } from '~/hooks/use-killswitch';
 
-// Notify react-query when the focused state changes
-AppState.addEventListener('change', (appState) => {
-  focusManager.setFocused(appState === 'active');
-});
-
 function Navigation() {
   const theme = useColorSchemeValue([DefaultTheme, DarkTheme]);
 
   useKillswitch();
+
+  useEffect(() => {
+    // Refetch queries on app focus
+    const subscription = AppState.addEventListener('change', (appState) => {
+      focusManager.setFocused(appState === 'active');
+    });
+
+    return () => subscription.remove();
+  }, []);
+
+  useEffect(() => {
+    // Refetch queries on reconnect
+    return NetInfo.addEventListener((state) => {
+      onlineManager.setOnline(!!state.isConnected);
+    });
+  }, []);
 
   return (
     <NavigationContainer

--- a/template/src/navigation/index.tsx
+++ b/template/src/navigation/index.tsx
@@ -4,10 +4,17 @@ import {
   DefaultTheme,
   DarkTheme,
 } from '@react-navigation/native';
+import { AppState } from 'react-native';
+import { focusManager } from '@tanstack/react-query';
 import RootNavigator from './RootNavigator';
 import { withBoundary } from '~/components/boundary';
 import { useColorSchemeValue } from '~/hooks/use-color-scheme-value';
 import { useKillswitch } from '~/hooks/use-killswitch';
+
+// Notify react-query when the focused state changes
+AppState.addEventListener('change', (appState) => {
+  focusManager.setFocused(appState === 'active');
+});
 
 function Navigation() {
   const theme = useColorSchemeValue([DefaultTheme, DarkTheme]);

--- a/template/src/navigation/index.tsx
+++ b/template/src/navigation/index.tsx
@@ -1,37 +1,22 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import {
   NavigationContainer,
   DefaultTheme,
   DarkTheme,
 } from '@react-navigation/native';
-import { AppState } from 'react-native';
-import { focusManager, onlineManager } from '@tanstack/react-query';
-import NetInfo from '@react-native-community/netinfo';
 import RootNavigator from './RootNavigator';
 import { withBoundary } from '~/components/boundary';
 import { useColorSchemeValue } from '~/hooks/use-color-scheme-value';
 import { useKillswitch } from '~/hooks/use-killswitch';
+import { useSetQueryFocusManager } from '~/hooks/use-set-query-focus-manager';
+import { useSetQueryOnlineManager } from '~/hooks/use-set-query-online-manager';
 
 function Navigation() {
   const theme = useColorSchemeValue([DefaultTheme, DarkTheme]);
 
   useKillswitch();
-
-  useEffect(() => {
-    // Refetch queries on app focus
-    const subscription = AppState.addEventListener('change', (appState) => {
-      focusManager.setFocused(appState === 'active');
-    });
-
-    return () => subscription.remove();
-  }, []);
-
-  useEffect(() => {
-    // Refetch queries on reconnect
-    return NetInfo.addEventListener((state) => {
-      onlineManager.setOnline(!!state.isConnected);
-    });
-  }, []);
+  useSetQueryFocusManager();
+  useSetQueryOnlineManager();
 
   return (
     <NavigationContainer

--- a/template/src/navigation/index.tsx
+++ b/template/src/navigation/index.tsx
@@ -10,13 +10,17 @@ import { useColorSchemeValue } from '~/hooks/use-color-scheme-value';
 import { useKillswitch } from '~/hooks/use-killswitch';
 import { useSetQueryFocusManager } from '~/hooks/use-set-query-focus-manager';
 import { useSetQueryOnlineManager } from '~/hooks/use-set-query-online-manager';
+import { useInvalidateQueriesOnLanguageChange } from '~/hooks/use-invalidate-queries-on-language-change';
 
 function Navigation() {
   const theme = useColorSchemeValue([DefaultTheme, DarkTheme]);
 
   useKillswitch();
+
   useSetQueryFocusManager();
   useSetQueryOnlineManager();
+
+  useInvalidateQueriesOnLanguageChange();
 
   return (
     <NavigationContainer


### PR DESCRIPTION
## 📖 Description

We notify react-query whenever the app gains focus or it put in the background so that queries can be refetched. We also invalidate the cache when the language changes to make sure that we have information in the right locale

## 🦀 Dispatch

- `#dispatch/react`
- `#dispatch/react-native`
