### PR TITLE
Removed babel plugin proposal class properties

### DIFF
--- a/template/babel.config.js
+++ b/template/babel.config.js
@@ -3,7 +3,6 @@ module.exports = {
   plugins: [
     'babel-plugin-transform-typescript-metadata',
     ['@babel/plugin-proposal-decorators', { legacy: true }],
-    ['@babel/plugin-proposal-class-properties', { loose: true }],
     [
       'module-resolver',
       {

--- a/template/package.json
+++ b/template/package.json
@@ -52,7 +52,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.22.0",
-    "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-proposal-decorators": "^7.23.0",
     "@babel/plugin-transform-class-static-block": "^7.22.11",
     "@babel/preset-env": "^7.22.20",

--- a/template/yarn.lock
+++ b/template/yarn.lock
@@ -409,7 +409,7 @@
     "@babel/helper-remap-async-to-generator" "^7.18.9"
     "@babel/plugin-syntax-async-generators" "^7.8.4"
 
-"@babel/plugin-proposal-class-properties@^7.0.0", "@babel/plugin-proposal-class-properties@^7.13.0", "@babel/plugin-proposal-class-properties@^7.18.0", "@babel/plugin-proposal-class-properties@^7.18.6":
+"@babel/plugin-proposal-class-properties@^7.0.0", "@babel/plugin-proposal-class-properties@^7.13.0", "@babel/plugin-proposal-class-properties@^7.18.0":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz#b110f59741895f7ec21a6fff696ec46265c446a3"
   integrity sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==


### PR DESCRIPTION
## 📖 Description

I tried using the boilerplate but was unable to use `<Flatlist />`. There was an error saying `Cannot read property 'getItem' of undefined`, it was thrown by `FlatList.js`. 

When is removed the babel plugin `@babel/plugin-proposal-class-properties` the problem was fixed.


<img width="250" src="https://github.com/mirego/react-native-boilerplate/assets/82352563/f426ed67-3112-4cbd-8454-8137f240c6db" />


## 🦀 Dispatch

- `#dispatch/react`
- `#dispatch/react-native`
