### PR TITLE
Update testing-library setup

### DIFF
--- a/template/__tests__/App.test.tsx
+++ b/template/__tests__/App.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { describe, it, beforeEach, afterEach } from '@jest/globals';
+import { describe, it, beforeEach, afterEach, expect } from '@jest/globals';
 import { screen, render, waitFor } from '@testing-library/react-native';
 import { container, singleton } from 'tsyringe';
 import App from '../src/App';

--- a/template/jest-setup.js
+++ b/template/jest-setup.js
@@ -1,5 +1,7 @@
 import 'reflect-metadata';
-import mockRNCNetInfo from '@react-native-community/netinfo/jest/netinfo-mock.js';
+import '@testing-library/react-native/extend-expect';
+import { jest } from '@jest/globals';
+import mockRNCNetInfo from '@react-native-community/netinfo/jest/netinfo-mock';
 import mockSafeAreaContext from 'react-native-safe-area-context/jest/mock';
 import mockDeviceInfo from 'react-native-device-info/jest/react-native-device-info-mock';
 

--- a/template/jest.config.js
+++ b/template/jest.config.js
@@ -1,7 +1,6 @@
 module.exports = {
   preset: 'react-native',
-  setupFiles: ['./jest-setup.js'],
-  setupFilesAfterEnv: ['@testing-library/jest-native/extend-expect'],
+  setupFilesAfterEnv: ['./jest-setup.js'],
   transformIgnorePatterns: [
     'node_modules/(?!(jest-)?react-native|@react-native|@react-native-community|@react-navigation|react-native-reanimated|@klarna|nanoid)',
   ],

--- a/template/package.json
+++ b/template/package.json
@@ -59,7 +59,6 @@
     "@react-native/eslint-config": "^0.73.1",
     "@react-native/metro-config": "^0.73.2",
     "@react-native/typescript-config": "^0.73.1",
-    "@testing-library/jest-native": "^5.4.3",
     "@testing-library/react-native": "^12.4.1",
     "@tsconfig/react-native": "^3.0.2",
     "@types/jest": "^29.5.5",

--- a/template/yarn.lock
+++ b/template/yarn.lock
@@ -2277,17 +2277,6 @@
   dependencies:
     "@tanstack/query-core" "5.12.1"
 
-"@testing-library/jest-native@^5.4.3":
-  version "5.4.3"
-  resolved "https://registry.yarnpkg.com/@testing-library/jest-native/-/jest-native-5.4.3.tgz#9334c68eaf45db9eb20d0876728cc5d7fc2c3ea2"
-  integrity sha512-/sSDGaOuE+PJ1Z9Kp4u7PQScSVVXGud59I/qsBFFJvIbcn4P6yYw6cBnBmbPF+X9aRIsTJRDl6gzw5ZkJNm66w==
-  dependencies:
-    chalk "^4.1.2"
-    jest-diff "^29.0.1"
-    jest-matcher-utils "^29.0.1"
-    pretty-format "^29.0.3"
-    redent "^3.0.0"
-
 "@testing-library/react-native@^12.4.1":
   version "12.4.1"
   resolved "https://registry.yarnpkg.com/@testing-library/react-native/-/react-native-12.4.1.tgz#f15d0b6727e5e1af8bc35049aa95ce24b4420fe7"
@@ -5148,7 +5137,7 @@ jest-config@^29.7.0:
     slash "^3.0.0"
     strip-json-comments "^3.1.1"
 
-jest-diff@^29.0.1, jest-diff@^29.7.0:
+jest-diff@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.7.0.tgz#017934a66ebb7ecf6f205e84699be10afd70458a"
   integrity sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==
@@ -5220,7 +5209,7 @@ jest-leak-detector@^29.7.0:
     jest-get-type "^29.6.3"
     pretty-format "^29.7.0"
 
-jest-matcher-utils@^29.0.1, jest-matcher-utils@^29.7.0:
+jest-matcher-utils@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz#ae8fec79ff249fd592ce80e3ee474e83a6c44f12"
   integrity sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==
@@ -6531,7 +6520,7 @@ pretty-format@^26.5.2, pretty-format@^26.6.2:
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
 
-pretty-format@^29.0.0, pretty-format@^29.0.3, pretty-format@^29.7.0:
+pretty-format@^29.0.0, pretty-format@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.7.0.tgz#ca42c758310f365bfa71a0bda0a807160b776812"
   integrity sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==


### PR DESCRIPTION
## 📖 Description

Matchers included in `@testing-library/jest-native` are now part of `@testing-library/react-native` now so we can change our config and remove the unused dependency